### PR TITLE
fix: dnit: Update import url for jszip

### DIFF
--- a/dnit/deps.ts
+++ b/dnit/deps.ts
@@ -24,6 +24,6 @@ export {
 } from 'https://denopkg.com/helix-collective/dnit-utils@v1.2.0/mod.ts';
 
 // other deno typescript libs:
-export * as jszip from 'https://deno.land/x/jszip@0.7.0/mod.ts';
+export * as jszip from 'https://denopkg.com/hayd/deno-zip@0.8.0/mod.ts';
 
 export * as changeCase from 'https://deno.land/x/case@v2.1.0/mod.ts';


### PR DESCRIPTION
workaround for error:

Warning std versions prefixed with 'v' were deprecated recently. Please change your import to https://deno.land/std@0.61.0/fs/mod.ts (at https://deno.land/std@v0.61.0/fs/mod.ts)
error: Import 'https://deno.land/std@v0.61.0/fs/mod.ts' failed: 404 Not Found
    at https://deno.land/x/jszip@0.7.0/mod.ts:2:0

jszip 0.8.0 from https://github.com/hayd/deno-zip/blob/0.8.0/mod.ts
isn't released on https://deno.land/x/jszip yet.

Using https://denopkg.com pulls it straight from github