### PR TITLE
Fix dnit docker run

### DIFF
--- a/dnit/deps.ts
+++ b/dnit/deps.ts
@@ -10,7 +10,7 @@ export {
   fs,
   Task,
   TrackedFile,
-} from 'https://deno.land/x/dnit@dnit-v1.11.0/mod.ts';
+} from 'https://deno.land/x/dnit@dnit-v1.12.1/mod.ts';
 
 // hx dnit-utils:
 export {

--- a/dnit/deps.ts
+++ b/dnit/deps.ts
@@ -21,7 +21,7 @@ export {
   dockerRun,
   currentUserOpts,
   confirmation,
-} from 'https://denopkg.com/helix-collective/dnit-utils@v1.2.0/mod.ts';
+} from 'https://denopkg.com/helix-collective/dnit-utils@v1.2.1/mod.ts';
 
 // other deno typescript libs:
 export * as jszip from 'https://denopkg.com/hayd/deno-zip@0.8.0/mod.ts';

--- a/dnit/docker.ts
+++ b/dnit/docker.ts
@@ -12,7 +12,7 @@ export async function runDockerizedTerraform(cmds: string[]): Promise<void> {
   const asUser = await currentUserOpts();
 
   await dockerRunConsole(TERRAFORM_IMAGE, {
-    interactive: false,
+    interactive: true,
     user: asUser.user,
     cmds: ['terraform', ...cmds],
     mounts: [


### PR DESCRIPTION
Previously:
runConsole did not provide stdin and so docker run -ti would error out with "terminal is not a TTY" - so docker run was set to NOT provide `--tty --interactive`

Fixed:
runConsole inherits parent stdin, so if the dnit process is running on a terminal then docker run -ti hooks up the docker contained process to the terminal IO - so docker run can be (and is) set to `--tty --interactive`

In particular this means that ctrl-c interrupt gets propagated properly into:
* dnit launcher
* deno main.ts
* docker run process
* the dockerised process (terraform)

Note:
dnit actions when running tasks do only what the ts code says
dnit doesn't have builtin code to run sub processes.

dnit-utils supplies various functions to run sub processes
they all use Deno.run eventually.

dnit-utils dockerRunConsole uses runConsole

dnit-utils runConsole has a bugfix:
`helix-collective/dnit-utils@d556d4d`

