### PR TITLE
Use npx instead of relative path when running ts-node

### DIFF
--- a/dnit/hx-terraform.ts
+++ b/dnit/hx-terraform.ts
@@ -44,7 +44,7 @@ export async function makeHxTerraformTasks(params: {yarn: YarnTasks}) : Promise<
     description: 'Generate typescript for providers',
     action: async () => {
       await runConsole(
-        ['./node_modules/.bin/ts-node', 'hx-terraform/tools/gen-providers.ts'],
+        ['npx', 'ts-node', 'hx-terraform/tools/gen-providers.ts'],
         {
           cwd: path.join(ROOT, 'typescript'),
         }
@@ -79,7 +79,7 @@ export async function makeHxTerraformTasks(params: {yarn: YarnTasks}) : Promise<
     name: 'generateTerraform',
     description: 'Generate terraform files from the terraform EDSL',
     action: async () => {
-      await runConsole(['./node_modules/.bin/ts-node', 'main.ts'], {
+      await runConsole(['npx','ts-node', 'main.ts'], {
         cwd: path.join(ROOT, 'typescript'),
       });
     },


### PR DESCRIPTION
Fixes an issue with running dnit on osx where calls to `runConsole` using a relative path would do something strange with how the console process was forked. 
The exact cause is unknown, but the solution here of changing from a relative path to using `npx` works as expected.

Note: Determined that these are the only locations that need to be fixed based on the below search:
```bash
/proto-infrastructure/typescript/hx-terraform (use-npx-instead-of-relative-path) skhouse $ git grep runConsole
dnit/deps.ts:  runConsole,
dnit/hx-terraform.ts:import { runAlways, asyncFiles, runConsole, Task, TrackedFile, trackFile, path, task } from './deps.ts'
dnit/hx-terraform.ts:      await runConsole(
dnit/hx-terraform.ts:      await runConsole(['npx','ts-node', 'main.ts'], {
dnit/lamdas.ts:import { runConsole, Task, changeCase } from './deps.ts'
dnit/lamdas.ts:      await runConsole(['yarn', 'build'], {
dnit/yarn.ts:import {task, runConsole, trackFile, path, Task} from './deps.ts'
dnit/yarn.ts:        await runConsole(['yarn'], {
```