### PR TITLE
Fix EOF generation.

### DIFF
--- a/core/core.ts
+++ b/core/core.ts
@@ -836,7 +836,7 @@ function quotedText(s: string) {
   if (needsQuoting) {
     const eof = getUniqueEof(s);
     const trailing = s.endsWith('\n') ? '' : '\n';
-    return `<<${eof}\n${s}${trailing}${eof}`;
+    return `<<${eof}\n${s}${trailing}${eof}\n`;
   }
   return JSON.stringify(s);
 }


### PR DESCRIPTION
For example when we create Route53 record which contains bare " we need
to explicitly add newline. Otherwise terraform complains about
non-terminated heredocs.