### PR TITLE
Add cloudfront_forwarded_values option for 'headers'

### DIFF
--- a/providers/aws/resources.ts
+++ b/providers/aws/resources.ts
@@ -4701,12 +4701,14 @@ export function fieldsFromCloudfrontDistributionParams(params: CloudfrontDistrib
 
 export interface CloudfrontForwardedValuesParams {
   cookies: CloudfrontCookiesParams;
+  headers?: (string)[];
   query_string: boolean;
 }
 
 export function fieldsFromCloudfrontForwardedValuesParams(params: CloudfrontForwardedValuesParams) : TF.ResourceFieldMap {
   const fields: TF.ResourceFieldMap = [];
   TF.addField(fields, "cookies", params.cookies, (v) => TF.mapValue(fieldsFromCloudfrontCookiesParams(v)));
+  TF.addOptionalField(fields, "headers", params.headers, TF.listValue(TF.stringValue));
   TF.addField(fields, "query_string", params.query_string, TF.booleanValue);
   return fields;
 }

--- a/tools/gen-providers.ts
+++ b/tools/gen-providers.ts
@@ -1522,6 +1522,7 @@ const cloudfront_forwarded_values: RecordDecl = {
   name: 'cloudfront_forwarded_values',
   fields: [
     requiredField('cookies', recordType(cloudfront_cookies)),
+    optionalField('headers', listType(STRING)),
     requiredField('query_string', BOOLEAN),
   ],
 };


### PR DESCRIPTION
See:
https://registry.terraform.io/providers/hashicorp/aws/2.70.0/docs/resources/cloudfront_distribution#headers

Use case:
Setting up a SSL proxy on cloudfront according to
https://developers.intercom.com/installing-intercom/docs/set-up-your-custom-domain