### PR TITLE
Add s3_bucket_public_access_block resource, and a helper functions to…

### DIFF
--- a/library/aws/s3.ts
+++ b/library/aws/s3.ts
@@ -67,3 +67,20 @@ export function createObjectFromFile(
     source: sourcePath,
   });
 }
+
+/**
+ * Block all public access for a bucket
+ */
+export function blockPublicAccess(
+  tfgen: TF.Generator,
+  tfname: string,
+  bucket: string
+) {
+  AR.createS3BucketPublicAccessBlock(tfgen, tfname, {
+    bucket,
+    block_public_acls: true,
+    block_public_policy: true,
+    restrict_public_buckets: true,
+    ignore_public_acls: true,
+  });
+}

--- a/library/aws/shared.ts
+++ b/library/aws/shared.ts
@@ -247,6 +247,9 @@ export function createSharedBucketsResources(tfgen: TF.Generator, params : Share
     tags: tfgen.tagsContext(),
     ...params.deploy,
   });
+  s3.blockPublicAccess(tfgen, 'deploy', deploy_bucket.id);
+
+  
 
   const backup_bucket_name = s3_bucket_prefix + '-shared-backups';
   const backup_bucket = AR.createS3Bucket(tfgen, 'backup', {
@@ -257,6 +260,8 @@ export function createSharedBucketsResources(tfgen: TF.Generator, params : Share
     tags: tfgen.tagsContext(),
     ...params.backup,
   });
+  s3.blockPublicAccess(tfgen, 'backup', backup_bucket.id);
+
 
   return {
     s3_bucket_prefix,

--- a/providers/aws/resources.ts
+++ b/providers/aws/resources.ts
@@ -594,6 +594,28 @@ export interface S3BucketObject extends TF.ResourceT<'S3BucketObject'> {
 export type S3BucketObjectId = {type:'S3BucketObjectId',value:string};
 
 /**
+ *  Manages S3 bucket-level Public Access Block configuration.
+ *
+ *  see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block
+ */
+export function createS3BucketPublicAccessBlock(tfgen: TF.Generator, rname: string, params: S3BucketPublicAccessBlockParams): S3BucketPublicAccessBlock {
+  const fields = fieldsFromS3BucketPublicAccessBlockParams(params);
+  const resource = tfgen.createTypedResource('S3BucketPublicAccessBlock', 'aws_s3_bucket_public_access_block', rname, fields);
+  const id: string =  '${' + TF.resourceName(resource) + '.id}';
+
+  return {
+    ...resource,
+    id,
+  };
+}
+
+export interface S3BucketPublicAccessBlock extends TF.ResourceT<'S3BucketPublicAccessBlock'> {
+  id: string;
+}
+
+export type S3BucketPublicAccessBlockId = {type:'S3BucketPublicAccessBlockId',value:string};
+
+/**
  *  Provides an SNS topic resource
  *
  *  see https://www.terraform.io/docs/providers/aws/r/sns_topic.html
@@ -2943,6 +2965,24 @@ export function fieldsFromS3BucketObjectParams(params: S3BucketObjectParams) : T
   TF.addField(fields, "key", params.key, TF.stringValue);
   TF.addOptionalField(fields, "source", params.source, TF.stringValue);
   TF.addOptionalField(fields, "content", params.content, TF.stringValue);
+  return fields;
+}
+
+export interface S3BucketPublicAccessBlockParams {
+  bucket: string;
+  block_public_acls?: boolean;
+  block_public_policy?: boolean;
+  ignore_public_acls?: boolean;
+  restrict_public_buckets?: boolean;
+}
+
+export function fieldsFromS3BucketPublicAccessBlockParams(params: S3BucketPublicAccessBlockParams) : TF.ResourceFieldMap {
+  const fields: TF.ResourceFieldMap = [];
+  TF.addField(fields, "bucket", params.bucket, TF.stringValue);
+  TF.addOptionalField(fields, "block_public_acls", params.block_public_acls, TF.booleanValue);
+  TF.addOptionalField(fields, "block_public_policy", params.block_public_policy, TF.booleanValue);
+  TF.addOptionalField(fields, "ignore_public_acls", params.ignore_public_acls, TF.booleanValue);
+  TF.addOptionalField(fields, "restrict_public_buckets", params.restrict_public_buckets, TF.booleanValue);
   return fields;
 }
 

--- a/tools/gen-providers.ts
+++ b/tools/gen-providers.ts
@@ -482,6 +482,17 @@ const s3_bucket_object: RecordDecl = {
   ],
 };
 
+const s3_bucket_public_access_block: RecordDecl = {
+  name: 's3_bucket_public_access_block',
+  fields: [
+    requiredField('bucket', STRING),
+    optionalField('block_public_acls', BOOLEAN),
+    optionalField('block_public_policy', BOOLEAN),
+    optionalField('ignore_public_acls', BOOLEAN),
+    optionalField('restrict_public_buckets', BOOLEAN),
+  ],
+};
+
 const iam_user: RecordDecl = {
   name: 'iam_user',
   fields: [
@@ -2363,6 +2374,14 @@ function generateAws(gen: Generator) {
   );
 
   gen.generateResource(
+    'Manages S3 bucket-level Public Access Block configuration.',
+    'https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block',
+    s3_bucket_public_access_block,
+    [stringAttr('id')]
+  );
+
+
+  gen.generateResource(
     'Provides an SNS topic resource',
     'https://www.terraform.io/docs/providers/aws/r/sns_topic.html',
     sns_topic,
@@ -3041,6 +3060,7 @@ function generateAws(gen: Generator) {
   gen.generateParams(s3_bucket);
   gen.generateParams(website);
   gen.generateParams(s3_bucket_object);
+  gen.generateParams(s3_bucket_public_access_block);
   gen.generateParams(sns_topic);
   gen.generateParams(iam_user);
   gen.generateParams(iam_user_policy);


### PR DESCRIPTION
… use it. Block public access to the existing deploy and backup shared buckets