### PR TITLE
Revert back to former tslint not-all-rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -1,10 +1,6 @@
 {
   "defaultSeverity": "error",
-  "extends": [
-    // Default to all rules - add exclusions in `rules` stanza
-    "tslint:all",
-    "tslint-config-prettier"
-  ],
+  "extends": ["tslint-config-airbnb", "tslint-config-prettier"],
   "jsRules": {},
   "rules": {
     // Decided to not have


### PR DESCRIPTION
"extends": ["tslint-config-airbnb", "tslint-config-prettier"],
is what projects inc proto-infrastructure were using.

Reverts tslint.json back to that of 71db7afc191c67ae6f18ebc10b344eaddd00db6f