### PR TITLE
Add more target_types

### DIFF
--- a/providers/aws/resources.ts
+++ b/providers/aws/resources.ts
@@ -3944,7 +3944,7 @@ export interface LbTargetGroupParams {
   proxy_protocol_v2?: boolean;
   stickiness?: LbTargetGroupStickinessParams;
   health_check?: LbTargetGroupHealthCheckParams;
-  target_type?: 'instance' | 'ip';
+  target_type?: 'instance' | 'ip' | 'lambda' | 'alb';
   tags?: TF.TagsMap;
 }
 

--- a/tools/gen-providers.ts
+++ b/tools/gen-providers.ts
@@ -850,7 +850,7 @@ const lb_target_group: RecordDecl = {
     optionalField('proxy_protocol_v2', BOOLEAN),
     optionalField('stickiness', recordType(lb_target_group_stickiness)),
     optionalField('health_check', recordType(lb_target_group_health_check)),
-    optionalField('target_type', enumType(['instance', 'ip'])),
+    optionalField('target_type', enumType(['instance', 'ip', 'lambda', 'alb'])),
     optionalField('tags', TAGS_MAP),
   ],
 };


### PR DESCRIPTION
According to https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateTargetGroup.html