### PR TITLE
Add ability to override generated name in LB.

### DIFF
--- a/library/aws/autoscale-deployment.ts
+++ b/library/aws/autoscale-deployment.ts
@@ -347,6 +347,7 @@ export function createLoadBalancer(tfgen: TF.Generator, tfname: string, sr: shar
   params: {
     acm_certificate_arn: AT.ArnT<'AcmCertificate'>,
     customize_lb?: Customize<AR.LbParams>;
+    alb_name?: string;
   } ): LoadBalancerAndListeners {
     const lbParams: AR.LbParams = {
       name: tfgen.scopedName(tfname).join('-'),
@@ -357,7 +358,7 @@ export function createLoadBalancer(tfgen: TF.Generator, tfname: string, sr: shar
     };
     const lb = AR.createLb(
       tfgen,
-      'alb',
+      params.alb_name || 'alb',
       applyCustomize(params.customize_lb, lbParams)
     );
   const lb_http_listener = AR.createLbListener(tfgen, tfname + '_http', {


### PR DESCRIPTION
We need to generate LBs with different names if we want to have multiple
LBs per environment. For example to have internal LB for south bound
services.

Easiest and cleanest solution is to use tfname for generated LoadBalancer
resource. However switching to that approach will cause mass
re-provisioning of whole infrastructure due name changes.