### PR TITLE
Support passing in comparison_operator to "createAutoScaleGroupActiveInstancesAlarm" and remove default threshold=50

### DIFF
--- a/library/aws/alarms.ts
+++ b/library/aws/alarms.ts
@@ -1,7 +1,7 @@
 import * as TF from '../../core/core';
 import * as AR from '../../providers/aws/resources';
 import { Customize } from "../util";
-import { CloudwatchMetricAlarmParams } from "../../providers/aws/resources";
+import { CloudwatchMetricAlarmParams, CloudwatchMetricAlarmComparisonOperator } from "../../providers/aws/resources";
 
 // How to prepare alarms:
 //    Use AWS console cloudwatch metrics to browse through metrics and pick instances/auto scale groups etc
@@ -382,7 +382,8 @@ export function createAutoScaleGroupActiveInstancesAlarm(
   tfgen: TF.Generator,
   topic: AR.SnsTopic,
   autoscaling_group: AR.AutoscalingGroup,
-  threshold: number = 50,
+  comparison_operator: CloudwatchMetricAlarmComparisonOperator,
+  threshold: number,
   period: number = 1,
   // MountPath: string = "/",
   evaluation_periods: number = 2,
@@ -394,7 +395,7 @@ export function createAutoScaleGroupActiveInstancesAlarm(
     period,
     threshold,
     alarm_name: tfgen.scopedName(name).join('_'),
-    comparison_operator: 'GreaterThanThreshold',
+    comparison_operator,
     metric_name: 'GroupInServiceInstances',
     namespace: 'AWS/AutoScaling',
     statistic: 'Average',

--- a/providers/aws/resources.ts
+++ b/providers/aws/resources.ts
@@ -1410,7 +1410,7 @@ export type LbTargetGroupId = {type:'LbTargetGroupId',value:string};
 export type LbTargetGroupArn = AT.ArnT<"LbTargetGroup">;
 
 /**
- *  Provides the ability to register instances and containers with an Application Load Balancer (ALB) or Network Load Balancer (NLB) target group. 
+ *  Provides the ability to register instances and containers with an Application Load Balancer (ALB) or Network Load Balancer (NLB) target group.
  *
  *  see https://www.terraform.io/docs/providers/aws/r/lb_target_group_attachment.html
  */
@@ -3187,7 +3187,7 @@ export interface RouteParams {
   Note according to the terraform docs
   'gateway_id - (Optional) Identifier of a VPC internet gateway or a virtual private gateway'
   Currently this 'or' is difficult to capture, so it has been left up to the client code
-  
+
   When using a vpn use the following in the client
   'gateway_id: { type: 'InternetGatewayId', value: vpn_gw.id.value }'
   */
@@ -3634,9 +3634,11 @@ export function fieldsFromDbSubnetGroupParams(params: DbSubnetGroupParams) : TF.
   return fields;
 }
 
+export type CloudwatchMetricAlarmComparisonOperator = 'GreaterThanOrEqualToThreshold' | 'GreaterThanThreshold' | 'LessThanThreshold' | 'LessThanOrEqualToThreshold';
+
 export interface CloudwatchMetricAlarmParams {
   alarm_name: string;
-  comparison_operator: 'GreaterThanOrEqualToThreshold' | 'GreaterThanThreshold' | 'LessThanThreshold' | 'LessThanOrEqualToThreshold';
+  comparison_operator: CloudwatchMetricAlarmComparisonOperator,
   /**
   The number of periods over which data is compared to the specified threshold.
   */


### PR DESCRIPTION
Using defaults for these parameters is a bad idea, the caller should explicitly make this decision. (Perhaps statistic should also be exposed...)