### PR TITLE
Feature/add es encryption

### DIFF
--- a/providers/aws/resources.ts
+++ b/providers/aws/resources.ts
@@ -4258,6 +4258,9 @@ export interface ElasticsearchDomainParams {
   cluster_config?: ElasticsearchDomainClusterConfigParams;
   snapshot_options?: ElasticsearchDomainSnapshotOptionsParams;
   cognito_options?: ElasticsearchDomainCognitoOptionsParams;
+  domain_endpoint_options?: ElasticsearchDomainEndpointOptionsParams;
+  encrypt_at_rest?: ElasticsearchEncryptAtRestParams;
+  node_to_node_encryption?: ElasticsearchNodeToNodeEncryptionParams;
   vpc_options?: ElasticsearchDomainVpcOptionsParams;
   elasticsearch_version?: string;
   tags?: TF.TagsMap;
@@ -4272,6 +4275,9 @@ export function fieldsFromElasticsearchDomainParams(params: ElasticsearchDomainP
   TF.addOptionalBlock(fields, "cluster_config", params.cluster_config, fieldsFromElasticsearchDomainClusterConfigParams);
   TF.addOptionalBlock(fields, "snapshot_options", params.snapshot_options, fieldsFromElasticsearchDomainSnapshotOptionsParams);
   TF.addOptionalBlock(fields, "cognito_options", params.cognito_options, fieldsFromElasticsearchDomainCognitoOptionsParams);
+  TF.addOptionalBlock(fields, "domain_endpoint_options", params.domain_endpoint_options, fieldsFromElasticsearchDomainEndpointOptionsParams);
+  TF.addOptionalBlock(fields, "encrypt_at_rest", params.encrypt_at_rest, fieldsFromElasticsearchEncryptAtRestParams);
+  TF.addOptionalBlock(fields, "node_to_node_encryption", params.node_to_node_encryption, fieldsFromElasticsearchNodeToNodeEncryptionParams);
   TF.addOptionalBlock(fields, "vpc_options", params.vpc_options, fieldsFromElasticsearchDomainVpcOptionsParams);
   TF.addOptionalAttribute(fields, "elasticsearch_version", params.elasticsearch_version, TF.stringValue);
   TF.addOptionalAttribute(fields, "tags", params.tags, TF.tagsValue);
@@ -4361,6 +4367,46 @@ export function fieldsFromElasticsearchDomainPolicyParams(params: ElasticsearchD
   const fields: TF.ResourceFieldMap = [];
   TF.addAttribute(fields, "domain_name", params.domain_name, TF.stringValue);
   TF.addOptionalAttribute(fields, "access_policies", params.access_policies, TF.stringValue);
+  return fields;
+}
+
+export interface ElasticsearchDomainEndpointOptionsParams {
+  custom_endpoint_certificate_arn?: AT.ArnT<"AcmCertificate">;
+  custom_endpoint_enabled?: boolean;
+  custom_endpoint?: string;
+  enforce_https?: boolean;
+  tls_security_policy?: string;
+}
+
+export function fieldsFromElasticsearchDomainEndpointOptionsParams(params: ElasticsearchDomainEndpointOptionsParams) : TF.ResourceFieldMap {
+  const fields: TF.ResourceFieldMap = [];
+  TF.addOptionalAttribute(fields, "custom_endpoint_certificate_arn", params.custom_endpoint_certificate_arn, TF.resourceArnValue);
+  TF.addOptionalAttribute(fields, "custom_endpoint_enabled", params.custom_endpoint_enabled, TF.booleanValue);
+  TF.addOptionalAttribute(fields, "custom_endpoint", params.custom_endpoint, TF.stringValue);
+  TF.addOptionalAttribute(fields, "enforce_https", params.enforce_https, TF.booleanValue);
+  TF.addOptionalAttribute(fields, "tls_security_policy", params.tls_security_policy, TF.stringValue);
+  return fields;
+}
+
+export interface ElasticsearchEncryptAtRestParams {
+  enabled: boolean;
+  kms_key_id?: string;
+}
+
+export function fieldsFromElasticsearchEncryptAtRestParams(params: ElasticsearchEncryptAtRestParams) : TF.ResourceFieldMap {
+  const fields: TF.ResourceFieldMap = [];
+  TF.addAttribute(fields, "enabled", params.enabled, TF.booleanValue);
+  TF.addOptionalAttribute(fields, "kms_key_id", params.kms_key_id, TF.stringValue);
+  return fields;
+}
+
+export interface ElasticsearchNodeToNodeEncryptionParams {
+  enabled: boolean;
+}
+
+export function fieldsFromElasticsearchNodeToNodeEncryptionParams(params: ElasticsearchNodeToNodeEncryptionParams) : TF.ResourceFieldMap {
+  const fields: TF.ResourceFieldMap = [];
+  TF.addAttribute(fields, "enabled", params.enabled, TF.booleanValue);
   return fields;
 }
 

--- a/tools/gen-providers.ts
+++ b/tools/gen-providers.ts
@@ -1126,6 +1126,32 @@ const elasticsearch_domain_cognito_options: RecordDecl = {
   ],
 };
 
+const elasticsearch_domain_endpoint_options: RecordDecl = {
+  name: 'elasticsearch_domain_endpoint_options',
+  fields: [
+    optionalField('custom_endpoint_certificate_arn', arnType(acm_certificate)),
+    optionalField('custom_endpoint_enabled', BOOLEAN),
+    optionalField('custom_endpoint', STRING),
+    optionalField('enforce_https', BOOLEAN),
+    optionalField('tls_security_policy', STRING),
+  ],
+};
+
+const elasticsearch_node_to_node_encryption: RecordDecl = {
+  name: 'elasticsearch_node_to_node_encryption',
+  fields: [
+    requiredField('enabled', BOOLEAN),
+  ],
+};
+
+const elasticsearch_encrypt_at_rest: RecordDecl = {
+  name: 'elasticsearch_encrypt_at_rest',
+  fields: [
+    requiredField('enabled', BOOLEAN),
+    optionalField('kms_key_id', STRING),
+  ],
+};
+
 const elasticsearch_domain: RecordDecl = {
   name: 'elasticsearch_domain',
   fields: [
@@ -1144,6 +1170,18 @@ const elasticsearch_domain: RecordDecl = {
     optionalField(
       'cognito_options',
       recordType(elasticsearch_domain_cognito_options)
+    ),
+    optionalField(
+      'domain_endpoint_options',
+      recordType(elasticsearch_domain_endpoint_options)
+    ),
+    optionalField(
+      'encrypt_at_rest',
+      recordType(elasticsearch_encrypt_at_rest)
+    ),
+    optionalField(
+      'node_to_node_encryption',
+      recordType(elasticsearch_node_to_node_encryption)
     ),
     optionalField('vpc_options', recordType(elasticsearch_domain_vpc_options)),
     optionalField('elasticsearch_version', STRING),
@@ -3886,6 +3924,9 @@ function generateAws(gen: Generator) {
   gen.generateParams(elasticsearch_domain_vpc_options);
   gen.generateParams(elasticsearch_domain_cognito_options);
   gen.generateParams(elasticsearch_domain_policy);
+  gen.generateParams(elasticsearch_domain_endpoint_options);
+  gen.generateParams(elasticsearch_encrypt_at_rest);
+  gen.generateParams(elasticsearch_node_to_node_encryption);
   gen.generateParams(acm_certificate);
   gen.generateParams(acm_certificate_validation);
   gen.generateParams(lb_listener_certificate);


### PR DESCRIPTION
Add options to modify encryption values in ES

Plan example

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_elasticsearch_domain.plp_logging-domain must be replaced
-/+ resource "aws_elasticsearch_domain" "plp_logging-domain" {
      ~ access_policies       = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = "es:*" -> [
                          + "es:*",
                        ]
                      ~ Principal = {
                          ~ AWS = "arn:aws:iam::326412704776:root" -> [
                              + "326412704776",
                            ]
                        }
                        # (2 unchanged elements hidden)
                    },
                ]
                # (1 unchanged element hidden)
            }
        )
      ~ advanced_options      = {
          - "override_main_response_version"         = "false"
          - "rest.action.multi.allow_explicit_index" = "true"
        } -> (known after apply)
      ~ arn                   = "arn:aws:es:ap-southeast-2:326412704776:domain/neara-logs" -> (known after apply)
      ~ domain_id             = "326412704776/neara-logs" -> (known after apply)
      ~ endpoint              = "search-neara-logs-drnh5edofz44y3xnckwtzxgjre.ap-southeast-2.es.amazonaws.com" -> (known after apply)
      ~ id                    = "arn:aws:es:ap-southeast-2:326412704776:domain/neara-logs" -> (known after apply)
      ~ kibana_endpoint       = "search-neara-logs-drnh5edofz44y3xnckwtzxgjre.ap-southeast-2.es.amazonaws.com/_plugin/kibana/" -> (known after apply)
        tags                  = {
            "cost-center"  = "plp"
            "tf-stack"     = "hxshared"
            "tf-subsystem" = "plp"
        }
        # (3 unchanged attributes hidden)

      ~ advanced_security_options {
          ~ enabled                        = false -> (known after apply)
          ~ internal_user_database_enabled = false -> (known after apply)

          + master_user_options {
              + master_user_arn      = (known after apply)
              + master_user_name     = (known after apply)
              + master_user_password = (sensitive value)
            }
        }

      ~ cluster_config {
          - warm_count               = 0 -> null
          - warm_enabled             = false -> null
          - zone_awareness_enabled   = false -> null
            # (5 unchanged attributes hidden)
        }

      - cognito_options {
          - enabled = false -> null
        }

      ~ domain_endpoint_options {
          ~ enforce_https           = false -> true
          ~ tls_security_policy     = "Policy-Min-TLS-1-0-2019-07" -> (known after apply)
            # (1 unchanged attribute hidden)
        }

      ~ ebs_options {
          - iops        = 0 -> null
            # (3 unchanged attributes hidden)
        }

      ~ encrypt_at_rest {
          ~ enabled    = false -> true # forces replacement
          + kms_key_id = (known after apply)
        }

      ~ node_to_node_encryption {
          ~ enabled = false -> true # forces replacement
        }

        # (1 unchanged block hidden)
    }

```