### PR TITLE
modifications needed to enable read replicas

### DIFF
--- a/library/aws/rds.ts
+++ b/library/aws/rds.ts
@@ -99,7 +99,7 @@ export function createPostgresInstance(
     publicly_accessible: false,
     backup_retention_period: 3,
     vpc_security_group_ids: [security_group.id],
-    db_subnet_group_name: db_subnet_group ? db_subnet_group.name: undefined,
+    db_subnet_group_name: db_subnet_group?.name,
     tags: tfgen.tagsContext(),
     final_snapshot_identifier: sname.replace(/_/g, '-') + '-final',
     skip_final_snapshot: false,

--- a/library/aws/rds.ts
+++ b/library/aws/rds.ts
@@ -55,7 +55,7 @@ export function createPostgresInstance(
     customize?: Customize<AR.DbInstanceParams>;
     customize_securitygroup?: Customize<AR.SecurityGroupParams>;
     force_ssl?: boolean,
-    subnet_ids: AR.SubnetId[];
+    subnet_ids?: AR.SubnetId[];
   }
 ): DbInstance {
   if(!params.db_name.match(/^[A-Za-z][A-Za-z0-9]+$/)) {
@@ -75,10 +75,10 @@ export function createPostgresInstance(
   }
   const security_group = AR.createSecurityGroup(tfgen, name, sg_params);
 
-  const db_subnet_group = AR.createDbSubnetGroup(tfgen, name, {
+  const db_subnet_group = params.subnet_ids ? AR.createDbSubnetGroup(tfgen, name, {
     name: sname,
     subnet_ids: params.subnet_ids,
-  });
+  }) : undefined;
 
   const db_parameter_group = params.force_ssl == undefined ? undefined : AR.createDbParameterGroup(tfgen, name, {
     family: 'postgres11',
@@ -99,7 +99,7 @@ export function createPostgresInstance(
     publicly_accessible: false,
     backup_retention_period: 3,
     vpc_security_group_ids: [security_group.id],
-    db_subnet_group_name: db_subnet_group.name,
+    db_subnet_group_name: db_subnet_group ? db_subnet_group.name: undefined,
     tags: tfgen.tagsContext(),
     final_snapshot_identifier: sname.replace(/_/g, '-') + '-final',
     skip_final_snapshot: false,

--- a/providers/aws/resources.ts
+++ b/providers/aws/resources.ts
@@ -3286,6 +3286,7 @@ export interface DbInstanceParams {
   iops?: number;
   snapshot_identifier?: string;
   monitoring_interval?: number;
+  monitoring_role_arn?: string;
 }
 
 export function fieldsFromDbInstanceParams(params: DbInstanceParams) : TF.ResourceFieldMap {
@@ -3320,6 +3321,7 @@ export function fieldsFromDbInstanceParams(params: DbInstanceParams) : TF.Resour
   TF.addOptionalAttribute(fields, "iops", params.iops, TF.numberValue);
   TF.addOptionalAttribute(fields, "snapshot_identifier", params.snapshot_identifier, TF.stringValue);
   TF.addOptionalAttribute(fields, "monitoring_interval", params.monitoring_interval, TF.numberValue);
+  TF.addOptionalAttribute(fields, "monitoring_role_arn", params.monitoring_role_arn, TF.stringValue);
   return fields;
 }
 

--- a/tools/gen-providers.ts
+++ b/tools/gen-providers.ts
@@ -149,6 +149,7 @@ const db_instance: RecordDecl = {
     optionalField('iops', NUMBER),
     optionalField('snapshot_identifier', STRING),
     optionalField('monitoring_interval', NUMBER),
+    optionalField('monitoring_role_arn', STRING),
   ],
 };
 


### PR DESCRIPTION
Changes are needed to be able to create read replicas

* subnets_id can't be added
* monitoring_role_arn is mandatory if the monitoring_interval is given