### PR TITLE
sort the deploy-context list before applying them

### DIFF
--- a/library/camus2/camus2.ts
+++ b/library/camus2/camus2.ts
@@ -218,7 +218,19 @@ export function configureCamus2(params: Camus2Params): bootscript.BootScript {
       throw Error(`proxy kind is unrecognised`);
   }
   const configSources: { [name: string]: C.JsonSource } = {};
-  params.deployContexts.forEach(dc => {
+  
+  // Avoid changes when the same list is build in different order
+  function sortFunc( a: DeployContext, b: DeployContext ) {
+    if ( a.name < b.name ){
+      return -1;
+    }
+    if ( a.name > b.name ){
+      return 1;
+    }
+    return 0;
+  }
+  const deployContextsSorted = params.deployContexts.sort(sortFunc)
+  deployContextsSorted.forEach(dc => {
     configSources[dc.name] = dc.source;
   });
 

--- a/library/camus2/camus2.ts
+++ b/library/camus2/camus2.ts
@@ -229,8 +229,7 @@ export function configureCamus2(params: Camus2Params): bootscript.BootScript {
     }
     return 0;
   }
-  const deployContextsSorted = params.deployContexts.sort(sortFunc)
-  deployContextsSorted.forEach(dc => {
+  params.deployContexts.sort(sortFunc).forEach(dc => {
     configSources[dc.name] = dc.source;
   });
 


### PR DESCRIPTION
The idea behind this is being able to build the DeployContext list in different places, but if its the same list, avoid replacements in user_data