### PR TITLE
add capability to enable autoscaling on RDS

### DIFF
--- a/providers/aws/resources.ts
+++ b/providers/aws/resources.ts
@@ -3399,6 +3399,7 @@ export interface DbInstanceParams {
   monitoring_interval?: number;
   monitoring_role_arn?: string;
   delete_automated_backups?: boolean;
+  max_allocated_storage?: number;
 }
 
 export function fieldsFromDbInstanceParams(params: DbInstanceParams) : TF.ResourceFieldMap {
@@ -3435,6 +3436,7 @@ export function fieldsFromDbInstanceParams(params: DbInstanceParams) : TF.Resour
   TF.addOptionalAttribute(fields, "monitoring_interval", params.monitoring_interval, TF.numberValue);
   TF.addOptionalAttribute(fields, "monitoring_role_arn", params.monitoring_role_arn, TF.stringValue);
   TF.addOptionalAttribute(fields, "delete_automated_backups", params.delete_automated_backups, TF.booleanValue);
+  TF.addOptionalAttribute(fields, "max_allocated_storage", params.max_allocated_storage, TF.numberValue);
   return fields;
 }
 

--- a/tools/gen-providers.ts
+++ b/tools/gen-providers.ts
@@ -152,6 +152,7 @@ const db_instance: RecordDecl = {
     optionalField('monitoring_interval', NUMBER),
     optionalField('monitoring_role_arn', STRING),
     optionalField('delete_automated_backups', BOOLEAN),
+    optionalField('max_allocated_storage', NUMBER),
   ],
 };
 


### PR DESCRIPTION
Enable autoscaling in RDS

[max_allocated_storage](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#max_allocated_storage) - (Optional) When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance. Configuring this will automatically ignore differences to allocated_storage. Must be greater than or equal to allocated_storage or 0 to disable Storage Autoscaling.