### PR TITLE
allow dummy tags to be ignored on instances

### DIFF
--- a/library/aws/autoscale-deployment.ts
+++ b/library/aws/autoscale-deployment.ts
@@ -167,6 +167,7 @@ export function createController(
       i.iam_instance_profile = controller_instance_profile.id;
       i.subnet_id = subnetId;
     },
+    tags_to_ignore: cparams.tags_to_ignore,
   });
 
   const controller_route53 = shared.dnsARecord(
@@ -780,6 +781,11 @@ export interface ControllerParams {
     * Instance type of the controller
     */
    instance_type?: AT.InstanceType;
+
+   /**
+    * Tags to ignore
+    */
+   tags_to_ignore?: string[];
 };
 
 

--- a/library/aws/ec2-deployment.ts
+++ b/library/aws/ec2-deployment.ts
@@ -52,6 +52,7 @@ export function createEc2Deployment(
         params.customize(i);
       }
     },
+    tags_to_ignore: params.tags_to_ignore
   });
   addDNS(tfgen, name, sr, params, appserver.eip.public_ip, params.public_dns_name);
   return appserver;
@@ -288,6 +289,8 @@ export interface Ec2InstanceDeploymentParams {
   frontendproxy_nginx_conf_tpl?: string;
   // Nginx version to use for camus2
   nginxDockerVersion?: string,
+  // What tags hx-tf should ignore on instances
+  tags_to_ignore?: string[];
 }
 
 // An Endpoint consists of a name and one or more connected


### PR DESCRIPTION
If you add a tag outside of terraform, it will get deleted. To be able to modify tags and terraform don't touch it you have to create them with terraform and a dummy value, and then tell terraform to ignore them. Then you can modify the tags all you want