### PR TITLE
remove intelligent tiering from deploy buckets

### DIFF
--- a/library/aws/shared.ts
+++ b/library/aws/shared.ts
@@ -259,7 +259,6 @@ export function createSharedBucketsResources(tfgen: TF.Generator, params : Share
     ...params.deploy,
   });
   s3.blockPublicAccess(tfgen, 'deploy', deploy_bucket.id);
-  enableS3IntelligentTiering(tfgen, deploy_bucket_name, {bucketName: deploy_bucket_name})
 
 
 


### PR DESCRIPTION
C2 doesn't support intelligent_tiering because the library is using hasn't been updated since 2019 (there an RC from 2021 that should contain this fixes, but is an RC not a release)

https://hackage.haskell.org/package/amazonka-s3-1.6.1/docs/Network-AWS-S3-Types.html#t:StorageClass
https://github.com/brendanhay/amazonka/releases
https://github.com/brendanhay/amazonka/issues/609